### PR TITLE
Declare soft dependency on formatR

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -11,7 +11,7 @@ License: GPL (>= 3)
 LazyData: yes
 Depends: R (>= 3.6), Matrix, graphics, stats (>= 2.14.0), methods
 Imports: systemfit (>= 1.1-20), MASS, vars, bvarsv, plm
-Suggests: knitr, rmarkdown
+Suggests: knitr, rmarkdown, formatR
 URL: https://github.com/icasas/tvReg
 BugReports: https://github.com/icasas/tvReg/issues
 Encoding: UTF-8


### PR DESCRIPTION
because of tidy = TRUE in the vignette: https://github.com/icasas/tvReg/blob/838c3d29a6d7b0e9d4323edef49dfdbe02b83883/vignettes/tvReg.Rmd#L25, otherwise formatR won't be available during `R CMD check --as-cran`.